### PR TITLE
Take the real part of the complete field

### DIFF
--- a/src/electricfield.jl
+++ b/src/electricfield.jl
@@ -6,14 +6,14 @@ function E(r, laser)
     E(x, y, coords, laser)
 end
 
-E(r, t, laser) = E(r, laser) * g(r[3], t, laser)
+E(r, t, laser) = real(E(r, laser) * g(r[3], t, laser))
 
 function E(x, y, coords, laser)
     E_x = Ex(laser, coords)
     E_y = Ey(laser, E_x)
     E_z = Ez(laser, coords, E_x, E_y, x, y)
 
-    real(Vec3(E_x, E_y, E_z))
+    Vec3(E_x, E_y, E_z)
 end
 
 Ey(laser, Ex) = laser.ξy / laser.ξx * Ex

--- a/src/envelopes.jl
+++ b/src/envelopes.jl
@@ -18,7 +18,7 @@ struct ConstantProfile end
 This envelope provides a finite duration for the laser pulse and thus can provide a more
 realistic description of an actual laser pulse.
 ```math
-envelope(z, t) = \\cosh\\left[\\left(\\frac{φ}{τ}\\right)^2\\right],
+envelope(z, t) = \\exp\\left[\\left(\\frac{φ}{τ}\\right)^2\\right],
 ```
 where
 ```math
@@ -79,9 +79,9 @@ which could offer better results than the Gaussian profile in the paraxial limit
 ```math
 envelope(z, t) =
     \\begin{cases}
-    \\cosh\\left[\\left(\\frac{φ}{τ}\\right)^2\\right], & \\text{for } φ ≤ 0\\\\
+    \\exp\\left[\\left(\\frac{φ}{τ}\\right)^2\\right], & \\text{for } φ ≤ 0\\\\
     1\\,, & \\text{for } φ < Δz\\\\
-    \\cosh\\left[\\left(\\frac{φ - Δz/c}{τ}\\right)^2\\right], & \\text{otherwise}
+    \\exp\\left[\\left(\\frac{φ - Δz/c}{τ}\\right)^2\\right], & \\text{otherwise}
     \\end{cases}
 ```
 where
@@ -110,7 +110,7 @@ end
 
 The time dependence of the fields defined by this package is given by
 ```math
-g(z, t) = \\cos(ω t) envelope(z, t),
+g(z, t) = \\exp(ω t) envelope(z, t),
 ```
 where
 - `z` and `t` are the position on the ``Oz`` axis and the time
@@ -122,7 +122,7 @@ and
 function g(z, t, par)
     @unpack profile, ω = par
 
-    cos(ω*t) * envelope(profile, z, t)
+    exp(im*ω*t) * envelope(profile, z, t)
 end
 
 envelope(::ConstantProfile, z, t) = 1
@@ -150,10 +150,10 @@ function envelope(profile::QuasiRectangularProfile, z, t)
     φ = (t - t₀) - (z - z₀) / c
 
     if φ < zero(φ)
-        cosh(uconvert(NoUnits, φ / τ)^2)
+        exp((φ / τ)^2)
     elseif φ < Δz
         one(φ)
     else
-        cosh(uconvert(NoUnits, (φ - Δz/c) / τ)^2)
+        exp(((φ - Δz/c) / τ)^2)
     end
 end

--- a/src/magneticfield.jl
+++ b/src/magneticfield.jl
@@ -6,7 +6,7 @@ function B(r, laser)
     B(x, y, coords, laser)
 end
 
-B(r, t, laser) = B(r, laser) * g(r[3], t, laser)
+B(r, t, laser) = real(B(r, laser) * g(r[3], t, laser))
 
 function B(x, y, coords, laser)
     E_x = Ex(laser, coords)
@@ -16,7 +16,7 @@ function B(x, y, coords, laser)
     B_y = By(laser, E_x)
     B_z = Bz(laser, coords, E_x, E_y, x, y)
 
-    real(Vec3(B_x, B_y, B_z))
+    Vec3(B_x, B_y, B_z)
 end
 
 Bx(laser, Ey) = -1/laser.c * Ey


### PR DESCRIPTION
I think that the previous implementation was wrong since we have to take the real part of the _complete_ filed, not just a part of if. Multiplying with `cos(ωt)` is not correct either.