### PR TITLE
Fixed copywrite errors in LG Ez and Bz.

### DIFF
--- a/src/LaserTypes.jl
+++ b/src/LaserTypes.jl
@@ -25,7 +25,7 @@ function w(z, par)
     w₀ * √(1 + (z/z_R)^2)
 end
 
-R(z, z_R) = z + z_R^2 / z
+# R(z, z_R) = z + z_R^2 / z
 
 include("envelopes.jl")
 include("electricfield.jl")

--- a/src/gauss.jl
+++ b/src/gauss.jl
@@ -57,7 +57,7 @@ function Ex(laser::GaussLaser, coords)
     wz = w(z, laser)
     Rz = R(z, z_R)
 
-    ξx * E₀ * w₀/wz * exp(-im*k*z - (r/wz)^2 - im*((k*r^2)/(2Rz) - atan(z, z_R) - ϕ₀))
+    ξx * E₀ * w₀/wz * exp(-im*k*z - (r/wz)^2 - im*(-(k*r^2)/(2Rz) - atan(z, z_R) - ϕ₀))
 end
 
 function Ez(laser::GaussLaser, coords, Ex, Ey, x, y)
@@ -65,8 +65,9 @@ function Ez(laser::GaussLaser, coords, Ex, Ey, x, y)
     z = coords.z
 
     wz = w(z, laser)
+    Rz = R(z, z_R)
 
-    2(im - z/z_R) / (k*wz^2) * (x*Ex + y*Ey)
+    (1/Rz + 2im/(k*wz^2)) * (x*Ex + y*Ey)
 end
 
 function Bz(laser::GaussLaser, coords, Ex, Ey, x, y)
@@ -74,6 +75,7 @@ function Bz(laser::GaussLaser, coords, Ex, Ey, x, y)
     z = coords.z
 
     wz = w(z, laser)
+    Rz = R(z, z_R)
 
-    2(im - z/z_R) / (c*k*wz^2) * (y*Ex - x*Ey)
+    (1/Rz + 2im/(k*wz^2))/c * (x*Ey - y*Ex)
 end

--- a/src/gauss.jl
+++ b/src/gauss.jl
@@ -55,9 +55,8 @@ function Ex(laser::GaussLaser, coords)
     @unpack r, z = coords
 
     wz = w(z, laser)
-    Rz = R(z, z_R)
 
-    ξx * E₀ * w₀/wz * exp(-im*k*z - (r/wz)^2 - im*(-(k*r^2)/(2Rz) - atan(z, z_R) - ϕ₀))
+    ξx * E₀ * w₀/wz * exp(-(r/wz)^2 + im*(-(r^2*z)/(z_R*wz^2) + atan(z, z_R) - k*z + ϕ₀))
 end
 
 function Ez(laser::GaussLaser, coords, Ex, Ey, x, y)
@@ -65,9 +64,8 @@ function Ez(laser::GaussLaser, coords, Ex, Ey, x, y)
     z = coords.z
 
     wz = w(z, laser)
-    Rz = R(z, z_R)
 
-    (1/Rz + 2im/(k*wz^2)) * (x*Ex + y*Ey)
+    2im/(k*wz^2)*(1 + im*(z/z_R))*(x*Ex + y*Ey)
 end
 
 function Bz(laser::GaussLaser, coords, Ex, Ey, x, y)
@@ -75,7 +73,6 @@ function Bz(laser::GaussLaser, coords, Ex, Ey, x, y)
     z = coords.z
 
     wz = w(z, laser)
-    Rz = R(z, z_R)
 
-    (1/Rz + 2im/(k*wz^2))/c * (x*Ey - y*Ex)
+    2im/(k*c*wz^2)*(1 + im*(z/z_R))*(y*Ex - x*Ey)
 end

--- a/src/laguerre-gauss.jl
+++ b/src/laguerre-gauss.jl
@@ -67,7 +67,7 @@ function required_coords(laser::LaguerreGaussLaser, r)
 end
 
 function Ex(laser::LaguerreGaussLaser, coords)
-    @unpack Nₚₘ, w₀, ϕ₀, z_R, ξx, p, m = laser
+    @unpack Nₚₘ, ϕ₀, z_R, ξx, p, m = laser
     @unpack r, θ, z = coords
 
     wz = w(z, laser)
@@ -76,15 +76,14 @@ function Ex(laser::LaguerreGaussLaser, coords)
     σ = (r/wz)^2
     mₐ = abs(m)
 
-    ξx*Eg*Nₚₘ*(r*√2/wz)^mₐ*_₁F₁(-p, mₐ+1, 2σ)*exp(im*((2p+mₐ)*atan(z, z_R)-m*θ-ϕ₀))
+    ξx * Eg * Nₚₘ * (r*√2/wz)^mₐ * _₁F₁(-p, mₐ+1, 2σ) * exp(im*((2p+mₐ)*atan(z, z_R) - m*θ + ϕ₀))
 end
 
 function Ez(laser::LaguerreGaussLaser, coords, E_x, E_y, x, y)
-    @unpack Nₚₘ, w₀, ϕ₀, k, z_R, p, m, ξx, ξy = laser
+    @unpack Nₚₘ, ϕ₀, k, z_R, p, m, ξx, ξy = laser
     @unpack r, θ, z = coords
 
     wz = w(z, laser)
-    Rz = R(z, z_R)
     mₐ = abs(m)
     σ = (r/wz)^2
     sgn = sign(m)
@@ -92,21 +91,20 @@ function Ez(laser::LaguerreGaussLaser, coords, E_x, E_y, x, y)
 
     gauss_laser = convert(GaussLaser, laser)
     Eg = Ex(gauss_laser, coords)
-    NEgexp = Nₚₘ*Eg*exp(im*((2p+mₐ)*atan(z, z_R)-m*θ-ϕ₀))
+    NEgexp = Nₚₘ*Eg*exp(im*((2p+mₐ)*atan(z, z_R)-m*θ+ϕ₀))
 
-    - im / k * (
-        (im*k/Rz - 2/wz^2)*(x*E_x + y*E_y) 
-        + (iszero(m) ? 𝟘 : NEgexp*_₁F₁(-p, mₐ+1, 2σ)*(√2/wz)^mₐ*r^(mₐ-1)*exp(im*sgn*θ)*mₐ*(ξx-im*sgn*ξy))
-        - (iszero(p) ? 𝟘 : NEgexp*_₁F₁(-p+1, mₐ+2, 2σ)*(r*√2/wz)^mₐ*(4p)/((mₐ+1)*wz^2)*(x*ξx + y*ξy))
-    )
+   -im/k * (
+       (iszero(m) ? 𝟘 : mₐ * (ξx - im*sgn*ξy) * (√2/wz)^mₐ * r^(mₐ-1) * _₁F₁(-p, mₐ+1, 2σ) * NEgexp * exp(im*sgn*θ)) 
+     - 2/(wz^2) * (1 + im*z/z_R) * (x*E_x + y*E_y)
+     - (iszero(p) ? 𝟘 : 4p/((mₐ+1) * wz^2) * (x*ξx + y*ξy) * (r*√2/wz)^mₐ * _₁F₁(-p+1, mₐ+2, 2σ) * NEgexp)
+   )
 end
 
 function Bz(laser::LaguerreGaussLaser, coords, E_x, E_y, x, y)
-    @unpack Nₚₘ, w₀, ϕ₀, k, ω, z_R, p, m, ξx, ξy = laser
+    @unpack Nₚₘ, ϕ₀, ω, z_R, p, m, ξx, ξy = laser
     @unpack r, θ, z = coords
 
     wz = w(z, laser)
-    Rz = R(z, z_R)
     σ = (r/wz)^2
     mₐ = abs(m)
     sgn = sign(m)
@@ -114,12 +112,11 @@ function Bz(laser::LaguerreGaussLaser, coords, E_x, E_y, x, y)
 
     gauss_laser = convert(GaussLaser, laser)
     Eg = Ex(gauss_laser, coords)
-    NEgexp = Nₚₘ*Eg*exp(im*((2p+mₐ)*atan(z, z_R)-m*θ-ϕ₀))
-    
-    -im / ω * (
-        (im*k/Rz - 2/wz^2)*(x*E_y - y*E_x) 
-        + (iszero(m) ? 𝟘 : NEgexp*_₁F₁(-p, mₐ+1, 2σ)*(√2/wz)^mₐ*r^(mₐ-1)*exp(im*sgn*θ)*mₐ*(ξy+im*sgn*ξx))
-        - (iszero(p) ? 𝟘 : NEgexp*_₁F₁(-p+1, mₐ+2, 2σ)*(r*√2/wz)^mₐ*(4p)/((mₐ+1)*wz^2)*(x*ξy - y*ξx))
-    ) 
+    NEgexp = Nₚₘ*Eg*exp(im*((2p+mₐ)*atan(z, z_R)-m*θ+ϕ₀))
 
+    -im/ω * (
+       - (iszero(m) ? 𝟘 : mₐ * (ξy + im*sgn*ξx) * (√2/wz)^mₐ*r^(mₐ-1) * _₁F₁(-p, mₐ+1, 2σ) * NEgexp * exp(im*sgn*θ))
+       + 2/(wz^2) * (1 + im*z/z_R) * (x*E_y - y*E_x) 
+       + (iszero(p) ? 𝟘 : (4p)/((mₐ+1) * wz^2) * (x*ξy - y*ξx) * (r*√2/wz)^mₐ * _₁F₁(-p+1, mₐ+2, 2σ) * NEgexp)
+    ) 
 end

--- a/test/laguerre-gauss.jl
+++ b/test/laguerre-gauss.jl
@@ -4,7 +4,7 @@ using StaticArrays
 using UnitfulAtomic
 using LinearAlgebra
 
-pochhammer(a::Int,b::Int) = factorial(a+b-1)/factorial(a-1)
+pochhammer = LaserTypes.pochhammer
 
 @testset "Values at origin" begin
     units = [:SI_unitful, :atomic_unitful, :SI, :atomic]

--- a/test/laguerre-gauss.jl
+++ b/test/laguerre-gauss.jl
@@ -4,6 +4,8 @@ using StaticArrays
 using UnitfulAtomic
 using LinearAlgebra
 
+pochhammer(a::Int,b::Int) = factorial(a+b-1)/factorial(a-1)
+
 @testset "Values at origin" begin
     units = [:SI_unitful, :atomic_unitful, :SI, :atomic]
     x₀ = SVector{3}(0u"μm",0u"μm",0u"μm")
@@ -21,7 +23,7 @@ using LinearAlgebra
         Bx, By, Bz = B(xᵢ, tᵢ,s)
         @test iszero(Bx)
         @test iszero(By)
-        @test iszero(Bz)
+        @test isapprox(Bz, - factorial(s.p)/pochhammer(abs(s.m)+1,s.p)*s.E₀*s.Nₚₘ*(√2*s.w₀)/(s.c*s.z_R))
     end
 end
 
@@ -45,4 +47,22 @@ end
     wXY = map(r -> wenergy₀(r[1],r[2]), Iterators.product(domainXY,domainXY))
     wMax = maximum(wXY)
     @test wMax < 1e6
+end
+
+@testset "LG(p = 0, m = 0, x, y, z, t) == G(x, y, z, t)" begin
+    ω = 0.057
+    T₀ = 2π/ω
+    c = 137.036
+    λ = c*T₀
+    w₀ = 75 * λ
+    a₀ = 2.
+    LG = setup_laser(LaguerreGaussLaser, :atomic, m = 0, p = 0, λ = λ, a₀ = a₀, w₀ = w₀,
+        profile=ConstantProfile())
+    G = setup_laser(GaussLaser, :atomic, λ = λ, a₀ = a₀, w₀ = w₀,
+        profile=ConstantProfile())
+    for i in 1:100
+        x, y, z = w₀ * (0.5 .- rand(3))
+        t = T₀ * rand()
+        @test Fμν([t*c, x, y, z], G) ≈ Fμν([t*c, x, y, z], LG) rtol = 1e-8
+    end
 end


### PR DESCRIPTION
I refactored the code that computes `Ez` and `Bz` for Gauss and Laguerre-Gauss. Added a check for `m = 0` and `p = 0` edge-cases and corrected some missing terms inside the formulae. 