### PR TITLE
Rewrite internals

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,14 @@ authors = ["Sebastian Micluța-Câmpeanu <m.c.sebastian95@gmail.com>"]
 version = "0.1.4"
 
 [deps]
+AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PhysicalConstants = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 

--- a/src/LaserTypes.jl
+++ b/src/LaserTypes.jl
@@ -9,25 +9,24 @@ export E, B,
 
 using Unitful
 using UnitfulAtomic
-using Parameters
+using UnPack
 using LinearAlgebra
 using HypergeometricFunctions
 using StaticArrays
 using CoordinateTransformations
-import PhysicalConstants.CODATA2018: c_0, m_e, e, μ_0
+using AutoHashEquals
+import PhysicalConstants.CODATA2018: c_0, e, m_e, ε_0, μ_0
 
 const _₁F₁ = HypergeometricFunctions.drummond1F1
 const pochhammer = HypergeometricFunctions.pochhammer
 
-function w(z, par)
-    @unpack w₀, z_R = par
-
-    w₀ * √(1 + (z/z_R)^2)
-end
-
-R(z, z_R) = z + z_R^2 / z
+abstract type AbstractLaser end
+abstract type AbstractTemporalProfile end
 
 include("envelopes.jl")
+include("constants.jl")
+include("coords.jl")
+include("polarization.jl")
 include("electricfield.jl")
 include("magneticfield.jl")
 include("faraday.jl")
@@ -35,5 +34,6 @@ include("gauss.jl")
 include("laguerre-gauss.jl")
 include("setup.jl")
 include("derived.jl")
+include("utils.jl")
 
 end # module

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,0 +1,17 @@
+struct FundamentalConstants{C,Q,M,E,Mu}
+    c::C
+    q::Q
+    mₑ::M
+    ε₀::E
+    μ₀::Mu
+end
+
+fundamental_constants(::Val{:SI_unitful}) = c_0, -e, m_e, ε_0, μ_0
+fundamental_constants(::Val{:SI}) = ustrip.(fundamental_constants(Val(:SI_unitful)))
+fundamental_constants(::Val{:atomic_unitful}) = auconvert.(fundamental_constants(Val(:SI_unitful)))
+fundamental_constants(::Val{:atomic}) = ustrip.(fundamental_constants(Val(:atomic_unitful)))
+
+function FundamentalConstants(units::Symbol)
+    constants = fundamental_constants(Val(units))
+    FundamentalConstants(constants...)
+end

--- a/src/coords.jl
+++ b/src/coords.jl
@@ -1,0 +1,47 @@
+struct LaserGeometry{D,R}
+    oscillation_dir::D
+    propagation_dir::D
+    rotation_matrix::R
+end
+
+function LaserGeometry(oscillation_dir, propagation_dir; isversor=false)
+    v₁ = !isversor ? normalize(oscillation_dir) : oscillation_dir
+    v₃ = !isversor ? normalize(propagation_dir) : propagation_dir
+    v₂ = v₃ × v₁
+
+    # original basis
+    e₁ = SVector{3}(1,0,0)
+    e₂ = SVector{3}(0,1,0)
+    e₃ = SVector{3}(0,0,1)
+
+    # original basis matrix
+    E = [e₁ e₂ e₃]
+
+    # desired direction matrix
+    V = [v₁ v₂ v₃]
+
+    # rotation matrix
+    R = E * transpose(V)
+
+    LaserGeometry(oscillation_dir, propagation_dir, R)
+end
+
+function sym2vec(dir::Symbol)
+    if dir == :x
+        SVector{3}(1,0,0)
+    elseif dir == :y
+        SVector{3}(0,1,0)
+    else
+        SVector{3}(0,0,1)
+    end
+end
+
+function LaserGeometry(oscillation_dir::Symbol, propagation_dir::Symbol)
+    if oscillation_dir == :x && propagation_dir == :z
+        return LaserGeometry(:x, :z, I)
+    end
+    v₁ = sym2vec(oscillation_dir)
+    v₃ = sym2vec(propagation_dir)
+
+    LaserGeometry(v₁, v₃, isversor=true)
+end

--- a/src/derived.jl
+++ b/src/derived.jl
@@ -8,6 +8,7 @@ Compute the [Poynting vector](https://en.wikipedia.org/wiki/Poynting_vector) def
 """
 function S(r, t, laser)
     ElectricField, MagneticField = EB(r, t, laser)
+    μ₀ = fundamental_constants(laser, :μ₀)
 
-    1 / laser.μ₀ * (ElectricField × MagneticField)
+    1 / μ₀ * (ElectricField × MagneticField)
 end

--- a/src/electricfield.jl
+++ b/src/electricfield.jl
@@ -1,19 +1,44 @@
 # # Electric Field
 
-function E(r, laser)
+function E(r, t, laser)
+    R = geometry(laser).rotation_matrix
+    r′ = rotate_coords(R, r)
+    inv_c = immutable_cache(laser, :inv_c)
+    if unit(eltype(r)) ≠ NoUnits
+        λ = laser.λ
+        r′ = uconvert.(unit(λ), r′)
+    end
+
+    ElectricField = real(E(r′, laser) * g(r′[3], t, laser; inv_c))
+
+    return inv_rotate(R, ElectricField)
+end
+
+function E(x::SVector{4}, laser::AbstractLaser)
+    inv_c = immutable_cache(laser, :inv_c)
+    r = x[SVector{3}(2,3,4)]
+    t = x[begin] * inv_c
+    E(r, t, laser)
+end
+
+function E(r, laser::AbstractLaser)
+    @assert length(r) == 3 "The laser is only defined in 3D"
+    fill!(mutable_cache(laser), r)
     coords = required_coords(laser, r)
-    x, y = r[1], r[2]
-    E(x, y, coords, laser)
-end
 
-E(r, t, laser) = real(E(r, laser) * g(r[3], t, laser))
-
-function E(x, y, coords, laser)
     E_x = Ex(laser, coords)
-    E_y = Ey(laser, E_x)
-    E_z = Ez(laser, coords, E_x, E_y, x, y)
+    update_cache!(laser, :Ex, E_x)
+    E_y = Ey(laser, coords)
+    update_cache!(laser, :Ey, E_y)
+    E_z = Ez(laser, coords)
+    update_cache!(laser, :Ez, E_z)
 
-    SVector{3}(E_x, E_y, E_z)
+    return SVector{3}(E_x, E_y, E_z)
 end
 
-Ey(laser, Ex) = laser.ξy / laser.ξx * Ex
+@inline function Ey(laser, coords)
+    @unpack ξx, ξy = polarization(laser)
+    @unpack Ex = mutable_cache(laser)
+
+    return ξy / ξx * Ex
+end

--- a/src/gauss.jl
+++ b/src/gauss.jl
@@ -1,5 +1,51 @@
 # # Gaussian profile
 
+struct GaussLaserConstantCache{IC,W,K,T,Z,E}
+    inv_c::IC
+    ω::W
+    k::K
+    T₀::T
+    z_R::Z
+    E₀::E
+end
+
+function GaussLaserConstantCache(;c, λ, w₀, a₀, mₑ, q)
+    ω = 2π * c / λ
+    k = 2π / λ
+    T = 2π / ω
+    z_R = w₀^2 * k / 2
+    E₀ = a₀ * mₑ * c * ω / abs(q)
+
+    return GaussLaserConstantCache(inv(c), ω, k, T, z_R, E₀)
+end
+
+@auto_hash_equals mutable struct GaussLaserCache{X,CE}
+    x::X
+    y::X
+    wz::X
+    Ex::CE
+    Ey::CE
+    Ez::CE
+end
+
+function GaussLaserCache(λ, E)
+    GaussLaserCache(
+        zero(λ),        # x
+        zero(λ),        # y
+        zero(λ),        # wz
+        zero(E*im),     # Ex
+        zero(E*im),     # Ey
+        zero(E*im)      # Ez
+    )
+end
+
+function Base.fill!(cache::GaussLaserCache, x::AbstractVector)
+    cache.x = x[1]
+    cache.y = x[2]
+
+    return nothing
+end
+
 @doc """
     struct GaussLaser{V,Q,M,L,F,C,T,P,W,K,E}
 
@@ -24,56 +70,92 @@ also computed
 """
 GaussLaser
 
-@with_kw struct GaussLaser{V,Q,M,M0,L1,L2,L3,F,C,T,P,W,K,E}
-    # independent values
-    c::V = c_0
-    q::Q = -e
-    m_q::M = m_e
-    μ₀::M0 = μ_0
-    λ::L1 = 0.8u"μm"
-    a₀::F = 1.0
-    ϕ₀::F = 0.0
-    w₀::L2 = 58.0u"μm"
-    ξx::C = 1.0 + 0im
-    ξy::C = 0.0 + 0im
-    @assert hypot(ξx, ξy) ≈ 1
-    profile::P = GaussProfile(c=c)
-    # derived values
-    ω::W = 2π * c / λ; @assert ω ≈ 2π * c / λ
-    k::K = 2π / λ; @assert k ≈ 2π / λ
-    z_R::L3 = w₀^2 * k / 2; @assert z_R ≈ w₀^2 * k / 2
-    T₀::T = 2π / ω; @assert T₀ ≈ 2π / ω
-    E₀::E = a₀ * m_q * c * ω / abs(q); @assert E₀ ≈ a₀ * m_q * c * ω / abs(q)
+struct GaussLaser{C0,Q,M,Eps,Mu,IC,W,K,T,Z,E,L,CE,D,R,C,P,F} <: AbstractLaser
+    constants::FundamentalConstants{C0,Q,M,Eps,Mu}
+    derived::GaussLaserConstantCache{IC,W,K,T,Z,E}
+    cache::GaussLaserCache{L,CE}
+    geometry::LaserGeometry{D,R}
+    polarization::LaserPolarization{C}
+    profile::P
+    # laser parameters
+    λ::L
+    a₀::F
+    ϕ₀::F
+    w₀::L
 end
 
-function required_coords(laser::GaussLaser, r)
+function GaussLaser(units;
+        λ,
+        a₀,
+        ϕ₀ = 0.0,
+        w₀,
+        ξx = 1.0+0im,
+        ξy = 0,
+        oscillation_dir = :x,
+        propagation_dir = :z,
+        profile = ConstantProfile()
+    )
+
+    ξx, ξy = promote(ξx, ξy)
+    a₀, ϕ₀ = promote(a₀, ϕ₀)
+    λ, w₀ = promote(λ, w₀)
+    @assert hypot(ξx, ξy) ≈ 1 "Invalid ξx and ξy"
+    constants = FundamentalConstants(units)
+    @unpack mₑ, c, q = constants
+
+    derived = GaussLaserConstantCache(; c, λ, w₀, a₀, mₑ, q)
+    E₀ = derived.E₀
+
+    cache = GaussLaserCache(λ, E₀)
+
+    geometry = LaserGeometry(oscillation_dir, propagation_dir)
+
+    polarization = LaserPolarization(ξx, ξy)
+
+    return GaussLaser(
+        constants,
+        derived,
+        cache,
+        geometry,
+        polarization,
+        profile,
+        λ,
+        a₀,
+        ϕ₀,
+        w₀
+    )
+end
+
+function required_coords(::GaussLaser, r)
     CylindricalFromCartesian()(r)
 end
 
 function Ex(laser::GaussLaser, coords)
-    @unpack E₀, w₀, k, z_R, ϕ₀, ξx = laser
+    @unpack E₀, k, z_R = immutable_cache(laser)
+    ξx = polarization(laser, :ξx)
+    @unpack w₀, ϕ₀ = laser
     @unpack r, z = coords
 
     wz = w(z, laser)
+    update_cache!(laser, :wz, wz)
     Rz = R(z, z_R)
 
     ξx * E₀ * w₀/wz * exp(-im*k*z - (r/wz)^2 - im*((k*r^2)/(2Rz) - atan(z, z_R) - ϕ₀))
 end
 
-function Ez(laser::GaussLaser, coords, Ex, Ey, x, y)
-    @unpack k, z_R = laser
+function Ez(laser::GaussLaser, coords)
+    @unpack k, z_R = immutable_cache(laser)
+    @unpack Ex, Ey, x, y, wz = mutable_cache(laser)
     z = coords.z
-
-    wz = w(z, laser)
 
     2(im - z/z_R) / (k*wz^2) * (x*Ex + y*Ey)
 end
 
-function Bz(laser::GaussLaser, coords, Ex, Ey, x, y)
-    @unpack k, z_R, c = laser
+function Bz(laser::GaussLaser, coords)
+    @unpack k, z_R = immutable_cache(laser)
+    @unpack Ex, Ey, x, y, wz = mutable_cache(laser)
+    c = fundamental_constants(laser, :c)
     z = coords.z
-
-    wz = w(z, laser)
 
     2(im - z/z_R) / (c*k*wz^2) * (y*Ex - x*Ey)
 end

--- a/src/laguerre-gauss.jl
+++ b/src/laguerre-gauss.jl
@@ -214,17 +214,17 @@ function Ez(laser::LaguerreGaussLaser, coords)
     update_cache!(laser, :NEgexp, NEgexp)
 
     -im/k * (
-       (iszero(m) ? 𝟘 : mₐ * (ξx - im*sgn*ξy) * (√2/wz)^mₐ * r^(mₐ-1) * _₁F₁(-p, mₐ+1, 2σ) * NEgexp * exp(im*sgn*θ)) 
+       (iszero(m) ? 𝟘 : mₐ * (ξx - im*sgn*ξy) * (√2/wz)^mₐ * r^(mₐ-1) * _₁F₁(-p, mₐ+1, 2σ) * NEgexp * exp(im*sgn*θ))
      - 2/(wz^2) * (1 + im*z/z_R) * (x*E_x + y*E_y)
      - (iszero(p) ? 𝟘 : 4p/((mₐ+1) * wz^2) * (x*ξx + y*ξy) * (r*√2/wz)^mₐ * _₁F₁(-p+1, mₐ+2, 2σ) * NEgexp)
-     )
+    )
 end
 
 function Bz(laser::LaguerreGaussLaser, coords)
-    @unpack Nₚₘ, k, z_R, inv_c = immutable_cache(laser)
-    @unpack wz, mₐ, Eg, Ex, Ey, NEgexp, x, y = mutable_cache(laser)
+    @unpack z_R = immutable_cache(laser)
+    @unpack wz, mₐ, Ex, NEgexp, x, y = mutable_cache(laser)
     @unpack ξx, ξy = polarization(laser)
-    @unpack ϕ₀, p, m = laser
+    @unpack p, m = laser
     @unpack r, θ, z = coords
 
     sgn = sign(m)
@@ -232,7 +232,7 @@ function Bz(laser::LaguerreGaussLaser, coords)
 
     -im/ω * (
        - (iszero(m) ? 𝟘 : mₐ * (ξy + im*sgn*ξx) * (√2/wz)^mₐ*r^(mₐ-1) * _₁F₁(-p, mₐ+1, 2σ) * NEgexp * exp(im*sgn*θ))
-       + 2/(wz^2) * (1 + im*z/z_R) * (x*E_y - y*E_x) 
+       + 2/(wz^2) * (1 + im*z/z_R) * (x*E_y - y*E_x)
        + (iszero(p) ? 𝟘 : (4p)/((mₐ+1) * wz^2) * (x*ξy - y*ξx) * (r*√2/wz)^mₐ * _₁F₁(-p+1, mₐ+2, 2σ) * NEgexp)
-    ) 
+    )
 end

--- a/src/magneticfield.jl
+++ b/src/magneticfield.jl
@@ -1,23 +1,53 @@
 # # Magnetic Field
 
-function B(r, laser)
-    coords = required_coords(laser, r)
-    x, y = r[1], r[2]
-    B(x, y, coords, laser)
+function B(r, t, laser)
+    R = geometry(laser).rotation_matrix
+    r′ = rotate_coords(R, r)
+    inv_c = immutable_cache(laser, :inv_c)
+    if unit(eltype(r)) ≠ NoUnits
+        λ = laser.λ
+        r′ = uconvert.(unit(λ), r′)
+    end
+
+    MagneticField = real(B(r′, laser) * g(r′[3], t, laser; inv_c))
+
+    return inv_rotate(R, MagneticField)
 end
 
-B(r, t, laser) = real(B(r, laser) * g(r[3], t, laser))
+function B(x::SVector{4}, laser::AbstractLaser)
+    inv_c = immutable_cache(laser, :inv_c)
+    r = x[SVector{3}(2,3,4)]
+    t = x[begin] * inv_c
+    B(r, t, laser)
+end
 
-function B(x, y, coords, laser)
+function B(r, laser::AbstractLaser)
+    @assert length(r) == 3 "The laser is only defined in 3D"
+    fill!(laser.cache, r)
+    coords = required_coords(laser, r)
+
     E_x = Ex(laser, coords)
-    E_y = Ey(laser, E_x)
+    update_cache!(laser, :Ex, E_x)
+    E_y = Ey(laser, coords)
+    update_cache!(laser, :Ey, E_y)
 
-    B_x = Bx(laser, E_y)
-    B_y = By(laser, E_x)
-    B_z = Bz(laser, coords, E_x, E_y, x, y)
+    B_x = Bx(laser, coords)
+    B_y = By(laser, coords)
+    B_z = Bz(laser, coords)
 
     SVector{3}(B_x, B_y, B_z)
 end
 
-Bx(laser, Ey) = -1/laser.c * Ey
-By(laser, Ex) = 1/laser.c * Ex
+@inline function Bx(laser, coords)
+    c = fundamental_constants(laser, :c)
+    Ey = mutable_cache(laser).Ey
+
+    -1/c * Ey
+end
+
+@inline function By(laser, coords)
+    c = fundamental_constants(laser, :c)
+    Ex = mutable_cache(laser).Ex
+
+    1/c * Ex
+end

--- a/src/polarization.jl
+++ b/src/polarization.jl
@@ -1,0 +1,4 @@
+struct LaserPolarization{C}
+    ξx::C
+    ξy::C
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,62 @@
+@inline fundamental_constants(laser::AbstractLaser) = getfield(laser, :constants)
+@inline fundamental_constants(laser::AbstractLaser, k) = getfield(laser.constants, k)
+@inline immutable_cache(laser::AbstractLaser) = getfield(laser, :derived)
+@inline immutable_cache(laser::AbstractLaser, k) = getfield(laser.derived, k)
+@inline mutable_cache(laser::AbstractLaser) = getfield(laser, :cache)
+@inline update_cache!(laser::AbstractLaser, k, v) = setfield!(laser.cache, k, v)
+@inline geometry(laser::AbstractLaser) = getfield(laser, :geometry)
+@inline polarization(laser::AbstractLaser) = getfield(laser, :polarization)
+@inline polarization(laser::AbstractLaser, k) = getfield(laser.polarization, k)
+@inline profile(laser::AbstractLaser) = getfield(laser, :profile)
+
+@inline function w(z, laser)
+    w₀ = laser.w₀
+    z_R = immutable_cache(laser, :z_R)
+
+    w₀ * √(1 + (z/z_R)^2)
+end
+
+@inline R(z, z_R) = z + z_R^2 / z
+
+@inline rotate_coords(R, r) = R * r
+@inline rotate_coords(::UniformScaling, r) = r
+@inline inv_rotate(R, r) = R \ r
+@inline inv_rotate(::UniformScaling, r) = r
+
+function Base.:(==)(a::AbstractLaser, b::AbstractLaser)
+    typeof(a) == typeof(b) &&
+    fundamental_constants(a) == fundamental_constants(b) &&
+    immutable_cache(a) == immutable_cache(b) &&
+    mutable_cache(a) == mutable_cache(b) &&
+    geometry(a) == geometry(b) &&
+    polarization(a) == polarization(b) &&
+    profile(a) == profile(b) &&
+    true
+end
+
+function Base.isequal(a::AbstractLaser, b::AbstractLaser)
+    t1 = typeof(a)
+    t2 = typeof(b)
+
+    isequal(t1, t2) &&
+    fundamental_constants(a) == fundamental_constants(b) &&
+    immutable_cache(a) == immutable_cache(b) &&
+    mutable_cache(a) == mutable_cache(b) &&
+    geometry(a) == mutable_cache(b) &&
+    polarization(a) == polarization(b) &&
+    profile(a) == profile(b) &&
+    true
+end
+
+function Base.hash(l::AbstractLaser, h::UInt)
+    constants = fundamental_constants(l)
+    derived = immutable_cache(l)
+    cache = mutable_cache(l)
+    geo = geometry(l)
+    pol = polarization(l)
+    prof = profile(l)
+
+    typename = Symbol(typeof(l))
+    hash(prof, hash(pol, hash(geo, hash(cache, hash(derived, hash(constants,
+        hash(typename, h)))))))
+end

--- a/test/dimensions.jl
+++ b/test/dimensions.jl
@@ -15,11 +15,11 @@ using UnitfulAtomic
         @test all(dimension.(E(xᵢ,tᵢ,s)) .== Ref(dimension(u"V/m")))
         @test all(dimension.(B(xᵢ,tᵢ,s)) .== Ref(dimension(u"T")))
 
-        @testset "Profiles" for profile in (ConstantProfile,
+        @testset "$profile" for profile in (ConstantProfile,
                                             GaussProfile,
                                             Cos²Profile,
                                             QuasiRectangularProfile)
-            s = setup_laser(laser, unit, profile=profile())
+            s = setup_laser(laser, unit; profile)
             @test all(dimension.(E(xᵢ,tᵢ,s)) .== Ref(dimension(u"V/m")))
             @test all(dimension.(B(xᵢ,tᵢ,s)) .== Ref(dimension(u"T")))
         end

--- a/test/faraday.jl
+++ b/test/faraday.jl
@@ -13,7 +13,7 @@ import PhysicalConstants.CODATA2018: c_0
     @testset "$unit" for (unit, xᵢ) in zip(units, x)
         s = setup_laser(laser, unit, profile=ConstantProfile())
         F = Fμν(xᵢ,s)
-        c = s.c
+        c = s.constants.c
 
         if unit ∈ [:SI_unitful, :atomic_unitful]
             @test all(dimension.(F) .== Ref(dimension(u"T")))

--- a/test/gauss.jl
+++ b/test/gauss.jl
@@ -1,4 +1,5 @@
 using LaserTypes, Test
+using LaserTypes: immutable_cache
 using Unitful
 using StaticArrays
 using UnitfulAtomic
@@ -12,13 +13,13 @@ using UnitfulAtomic
     @testset "$unit" for (unit, xᵢ) in zip(units, x)
         s = setup_laser(GaussLaser, unit, profile=ConstantProfile())
         Ex, Ey, Ez = E(xᵢ, s)
-        @test Ex ≈ s.E₀
+        @test Ex ≈ immutable_cache(s, :E₀)
         @test iszero(Ey)
         @test iszero(Ez)
 
         Bx, By, Bz = B(xᵢ, s)
         @test iszero(Bx)
-        @test By ≈ s.E₀ / s.c
+        @test By ≈ immutable_cache(s, :E₀) * immutable_cache(s, :inv_c)
         @test iszero(Bz)
     end
 end

--- a/test/laguerre-gauss.jl
+++ b/test/laguerre-gauss.jl
@@ -10,7 +10,7 @@ using LinearAlgebra
     t₀ = 0u"s"
     x = (x₀, auconvert.(x₀), ustrip.(x₀), ustrip.(auconvert.(x₀)))
     t = (t₀, auconvert.(t₀), ustrip.(t₀), ustrip.(auconvert.(t₀)))
-    
+
     @testset "$unit" for (unit, xᵢ, tᵢ) in zip(units, x, t)
         s = setup_laser(LaguerreGaussLaser, unit, m = 1, p = 1, profile=ConstantProfile())
         Ex, Ey, Ez = E(xᵢ, tᵢ, s)
@@ -34,7 +34,7 @@ end
     a₀ = 2.
     s = setup_laser(LaguerreGaussLaser, :atomic, m = 1, p = 1, λ = λ, a₀ = a₀, w₀ = w₀,
         profile=ConstantProfile())
-   
+
     fieldE(x,y,z,t) = E([x,y,z],t,s)
     fieldB(x,y,z,t) = B([x,y,z],t,s)
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -11,13 +11,13 @@ import PhysicalConstants.CODATA2018: c_0, m_e, μ_0, e, α
     w0 = 58.0u"μm"
     τ = 18.0u"fs"
     a₀ = 2.0
-    p = GaussLaser(c=c, q=q, m_q=m, λ=λ, w₀=w0, a₀=2.0, profile=GaussProfile(c=c,τ=τ))
-    s = setup_laser(GaussLaser, :SI_unitful, a₀=2.0)
+    p = GaussLaser(:SI_unitful; λ, w₀=w0, a₀=2.0, profile=GaussProfile(;τ,z₀=0.0u"μm"))
+    s = setup_laser(GaussLaser, :SI_unitful; a₀=2.0, profile = GaussProfile, τ)
     @test p == s
 
-    @test unit(s.c) == u"m/s"
-    @test unit(s.k) == u"μm^-1"
-    @test unit(s.z_R) == u"μm"
+    @test unit(s.constants.c) == u"m/s"
+    @test unit(s.derived.k) == u"μm^-1"
+    @test unit(s.derived.z_R) == u"μm"
 end
 
 @testset "Atomic Unitful" begin
@@ -30,14 +30,14 @@ end
     τ = auconvert(18u"fs")
     a₀=2.0
 
-    p = GaussLaser(c=c, q=q, m_q=m, μ₀=μ₀, λ=λ, w₀=w0, a₀=2.0, profile=GaussProfile(c=c,τ=τ))
-    s = setup_laser(GaussLaser, a₀=2.0, :atomic_unitful)
+    p = GaussLaser(:atomic_unitful; λ, w₀=w0, a₀=2.0, profile=GaussProfile(;τ,z₀=0.0u"a0_au"))
+    s = setup_laser(GaussLaser, :atomic_unitful; a₀=2.0, profile = GaussProfile, τ)
     @test p == s
 
-    @test unit(s.c) == u"a0_au*Eh_au/ħ_au"
-    @test unit(s.k) == u"a0_au^-1"
-    @test unit(s.z_R) == u"a0_au"
-    @test s.ω ≈ 0.05695419u"Eh_au/ħ_au"
+    @test unit(s.constants.c) == u"a0_au*Eh_au/ħ_au"
+    @test unit(s.derived.k) == u"a0_au^-1"
+    @test unit(s.derived.z_R) == u"a0_au"
+    @test s.derived.ω ≈ 0.05695419u"Eh_au/ħ_au"
 end
 
 @testset "SI" begin
@@ -48,11 +48,11 @@ end
     λ = ustrip(u"m", 0.8u"μm")
     w0 = ustrip(u"m", 58.0u"μm")
     τ = ustrip(u"s", 18.0u"fs")
-    p = GaussLaser(c=c, q=q, m_q=m, μ₀=μ₀, λ=λ, w₀=w0, a₀=2.0, profile=GaussProfile(c=c,τ=τ))
+    p = GaussLaser(:SI; λ, w₀=w0, a₀=2.0, profile=GaussProfile(;τ, z₀=0.0))
     s = setup_laser(GaussLaser, :SI, a₀=2.0)
     @test p == s
 
-    @test s.ω ≈ 2.354564459e15
+    @test s.derived.ω ≈ 2.354564459e15
 end
 
 @testset "Atomic" begin
@@ -65,9 +65,9 @@ end
     τ = ustrip(auconvert(18u"fs"))
     a₀=2.0
 
-    p = GaussLaser(c=c, q=q, m_q=m, μ₀=μ₀, λ=λ, w₀=w0, a₀=2.0, profile=GaussProfile(c=c,τ=τ))
+    p = GaussLaser(:atomic; λ, w₀=w0, a₀=2.0, profile=GaussProfile(τ=τ, z₀=0.0))
     s = setup_laser(GaussLaser, :atomic, a₀=2.0)
     @test p == s
 
-    @test s.ω ≈ 0.05695419
+    @test s.derived.ω ≈ 0.05695419
 end


### PR DESCRIPTION
The laser structs have been refactored to incorporate mutable and immutable caches so that we don't need to transfer variables between functions through function arguments.

TODO:
- [x] Resolve conflicts

Edit: Moved the rest of the TODO list to: https://github.com/SebastianM-C/LaserTypes.jl/issues/39